### PR TITLE
Update RSS

### DIFF
--- a/events.yaml
+++ b/events.yaml
@@ -159,10 +159,10 @@
 
 - title: "Robotics: Science and Systems 2024"
   link: https://roboticsconference.org/
-  start_date: 2024-07-10
-  end_date: 2024-07-14
-  city: Daegu
-  country: Republic of Korea
+  start_date: 2024-07-15
+  end_date: 2024-07-19
+  city: Delft
+  country: The Netherlands
   category: Conference
 
 - title: RoboCup 2024


### PR DESCRIPTION
I was mistaken about robotics systems and science conference. It was in Korera in 2023, but in 2024 it will be in the netherlands! The link still points to the old website but I think the new one will be online quickly