### PR TITLE
Add an option to include event deadlines

### DIFF
--- a/events.yaml
+++ b/events.yaml
@@ -3,6 +3,7 @@
 #   link: your event link
 #   start_date: YYYY-MM-DD
 #   end_date: YYYY-MM-DD # Optional
+#   deadline: YYYY-MM-DD # Optional
 #   city: event city
 #   country: event country
 #   category: Conference # Options: Conference, Expo, Workshop, Competition, Meetup

--- a/events.yaml
+++ b/events.yaml
@@ -23,7 +23,7 @@
   category: Meetup
 
 - title: ROS Meetup Lagos 2024
-  link: 
+  link:
     https://docs.google.com/forms/d/e/1FAIpQLSdWL1mek_lxOX1RpLd8vSPlqLNwzUhnhya7uimQ0NABNz8VNA/viewform
   start_date: 2024-02-03
   city: Lagos
@@ -39,7 +39,7 @@
   category: Conference
 
 - title: ROS Meetup Munich 2024
-  link: 
+  link:
     https://www.linkedin.com/events/6thros-robotics-meetup-7thfebru7148710255919628288/about/
   start_date: 2024-02-07
   city: Munich
@@ -162,6 +162,7 @@
   link: https://www.aira-challenge.com
   start_date: 2024-06-10
   end_date: 2024-06-14
+  deadline: 2024-01-07
   city: Frankfurt am Main
   country: Germany
   category: Competition
@@ -202,6 +203,7 @@
   link: https://www.ursc.gov.in/IRoC-U2024/events.jsp#main
   start_date: 2024-08-05
   end_date: 2024-08-06
+  deadline: 2024-01-15
   city: Bengaluru
   country: India
   category: Competition
@@ -217,6 +219,7 @@
 - title: Farm Robotics Challenge
   link: https://farmroboticschallenge.ai/
   start_date: 2024-09-06
+  deadline: 2023-12-18
   city: tbd
   country: United States of America
   category: Competition
@@ -257,6 +260,7 @@
   link: https://cybathlon.ethz.ch/en/events/edition/cybathlon-2024
   start_date: 2024-10-25
   end_date: 2024-10-27
+  deadline: 2024-03-31
   city: Kloten
   country: Switzerland
   category: Competition

--- a/scripts/templates/readme.j2
+++ b/scripts/templates/readme.j2
@@ -32,5 +32,5 @@ When you insert the event, make sure it is inserted chronologically with respect
 ## {{ category }}
 
 {% for event in events %}
-* [{{ event.title }}]({{ event.link }}){% if event.end_date %}: {{ event.start_date.strftime('%b %d') }}-{{ event.end_date.strftime('%b %d, %Y') }}.{% else %}: {{ event.start_date.strftime('%b %d, %Y') }}.{% endif %} {{ event.city }}, {{ event.country }}{% endfor %}
+* [{{ event.title }}]({{ event.link }}){% if event.end_date %}: {{ event.start_date.strftime('%b %d') }}-{{ event.end_date.strftime('%b %d, %Y') }}.{% else %}: {{ event.start_date.strftime('%b %d, %Y') }}{% if event.deadline %} (ddl: {{event.deadline.strftime('%b %d, %Y')}}){% endif %}.{% endif %} {{ event.city }}, {{ event.country }}{% endfor %}
 {% endfor %}


### PR DESCRIPTION
This feature adds parsing of deadline field in the events.yaml, resolving #20. The deadline field can be applied to any kind of event. Will make a separate PR to add deadlines to some of the challenges.